### PR TITLE
Replaced all copyright in remaining files with GPL license

### DIFF
--- a/.mgproj
+++ b/.mgproj
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2016 Minoca Corp. All Rights Reserved
+Copyright (c) 2016 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/ck/Makefile
+++ b/apps/ck/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/ck/app/Makefile
+++ b/apps/ck/app/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/ck/app/build/Makefile
+++ b/apps/ck/app/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/ck/app/sources
+++ b/apps/ck/app/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/lib/Makefile
+++ b/apps/ck/lib/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/lib/build/Makefile
+++ b/apps/ck/lib/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/lib/build/dynamic/Makefile
+++ b/apps/ck/lib/build/dynamic/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/lib/dynamic/Makefile
+++ b/apps/ck/lib/dynamic/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/lib/gram/Makefile
+++ b/apps/ck/lib/gram/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/ck/lib/sources
+++ b/apps/ck/lib/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/modules/Makefile
+++ b/apps/ck/modules/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/ck/modules/app/Makefile
+++ b/apps/ck/modules/app/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/modules/app/build/Makefile
+++ b/apps/ck/modules/app/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/modules/app/sources
+++ b/apps/ck/modules/app/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/modules/bundle/Makefile
+++ b/apps/ck/modules/bundle/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/modules/bundle/build/Makefile
+++ b/apps/ck/modules/bundle/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/modules/bundle/sources
+++ b/apps/ck/modules/bundle/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/modules/os/Makefile
+++ b/apps/ck/modules/os/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/modules/os/build/Makefile
+++ b/apps/ck/modules/os/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/modules/os/build/dynamic/Makefile
+++ b/apps/ck/modules/os/build/dynamic/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/modules/os/dynamic/Makefile
+++ b/apps/ck/modules/os/dynamic/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/ck/modules/os/sources
+++ b/apps/ck/modules/os/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/debug/Makefile
+++ b/apps/debug/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/debug/client/Makefile
+++ b/apps/debug/client/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/debug/client/minoca/Makefile
+++ b/apps/debug/client/minoca/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/debug/client/sources
+++ b/apps/debug/client/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/apps/debug/client/tdwarf/Makefile
+++ b/apps/debug/client/tdwarf/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/debug/client/testdisa/Makefile
+++ b/apps/debug/client/testdisa/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/debug/client/teststab/Makefile
+++ b/apps/debug/client/teststab/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/debug/client/win32/Makefile
+++ b/apps/debug/client/win32/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/debug/client/win32/cmdln/Makefile
+++ b/apps/debug/client/win32/cmdln/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/debug/client/win32/ui/Makefile
+++ b/apps/debug/client/win32/ui/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/debug/dbgext/Makefile
+++ b/apps/debug/dbgext/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/debug/dbgext/win32/Makefile
+++ b/apps/debug/dbgext/win32/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/debug/kexts/Makefile
+++ b/apps/debug/kexts/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/debug/kexts/win32/Makefile
+++ b/apps/debug/kexts/win32/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/efiboot/Makefile
+++ b/apps/efiboot/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/lib/Makefile
+++ b/apps/lib/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/lib/chalk/Makefile
+++ b/apps/lib/chalk/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/lib/chalk/build/Makefile
+++ b/apps/lib/chalk/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/lib/chalk/sources
+++ b/apps/lib/chalk/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/libc/Makefile
+++ b/apps/libc/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/libc/crypt/Makefile
+++ b/apps/libc/crypt/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/libc/dynamic/Makefile
+++ b/apps/libc/dynamic/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/libc/dynamic/pthread/Makefile
+++ b/apps/libc/dynamic/pthread/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/libc/dynamic/pthread/static/Makefile
+++ b/apps/libc/dynamic/pthread/static/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/libc/dynamic/testc/Makefile
+++ b/apps/libc/dynamic/testc/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/libc/dynamic/wincsup/Makefile
+++ b/apps/libc/dynamic/wincsup/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved.
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information..
 #
 #   Module Name:
 #

--- a/apps/libc/static/Makefile
+++ b/apps/libc/static/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/mingen/Makefile
+++ b/apps/mingen/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/mingen/build/Makefile
+++ b/apps/mingen/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/mingen/sources
+++ b/apps/mingen/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/apps/mount/Makefile
+++ b/apps/mount/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/netcon/Makefile
+++ b/apps/netcon/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/netlink/Makefile
+++ b/apps/netlink/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/osbase/Makefile
+++ b/apps/osbase/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/osbase/urtl/Makefile
+++ b/apps/osbase/urtl/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/posix/Makefile
+++ b/apps/posix/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/posix/init.d/init-functions
+++ b/apps/posix/init.d/init-functions
@@ -1,5 +1,10 @@
 #! /bin/sh
-## Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2015 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/apps/posix/init.d/rc
+++ b/apps/posix/init.d/rc
@@ -1,5 +1,10 @@
 #! /bin/sh
-## Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2015 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/apps/posix/update-rc.d
+++ b/apps/posix/update-rc.d
@@ -1,5 +1,10 @@
 #! /bin/sh
-## Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2015 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##
@@ -308,12 +313,12 @@ while [ -n "$1" ] ; do
             rename_links "S" "K" "$name" "$runlevels"
         fi
         ;;
-        
+
     *)
         echo "$me: Error: Unexpected argument $action."
         exit 1
         ;;
-        
+
     esac
 done
 

--- a/apps/profile/Makefile
+++ b/apps/profile/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/setup/Makefile
+++ b/apps/setup/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/setup/sources
+++ b/apps/setup/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/apps/setup/uos/Makefile
+++ b/apps/setup/uos/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/setup/win32/Makefile
+++ b/apps/setup/win32/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/swiss/Makefile
+++ b/apps/swiss/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/swiss/cposs.sh
+++ b/apps/swiss/cposs.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2016 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2016 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/apps/swiss/sources
+++ b/apps/swiss/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/apps/swiss/uos/Makefile
+++ b/apps/swiss/uos/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/swiss/win32/Makefile
+++ b/apps/swiss/win32/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/testapps/Makefile
+++ b/apps/testapps/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/testapps/aiotest/Makefile
+++ b/apps/testapps/aiotest/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/testapps/dbgtest/Makefile
+++ b/apps/testapps/dbgtest/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/testapps/filetest/Makefile
+++ b/apps/testapps/filetest/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/testapps/ktest/Makefile
+++ b/apps/testapps/ktest/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/testapps/ktest/driver/Makefile
+++ b/apps/testapps/ktest/driver/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/apps/testapps/mmaptest/Makefile
+++ b/apps/testapps/mmaptest/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/testapps/mnttest/Makefile
+++ b/apps/testapps/mnttest/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/testapps/pathtest/Makefile
+++ b/apps/testapps/pathtest/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/testapps/perftest/Makefile
+++ b/apps/testapps/perftest/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/testapps/perftest/perflib/Makefile
+++ b/apps/testapps/perftest/perflib/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/testapps/sigtest/Makefile
+++ b/apps/testapps/sigtest/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/testapps/socktest/Makefile
+++ b/apps/testapps/socktest/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/testapps/utmrtest/Makefile
+++ b/apps/testapps/utmrtest/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/tzcomp/Makefile
+++ b/apps/tzcomp/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/unmount/Makefile
+++ b/apps/unmount/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/apps/vmstat/Makefile
+++ b/apps/vmstat/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/Makefile
+++ b/boot/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/bootman/Makefile
+++ b/boot/bootman/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/bootman/efi/Makefile
+++ b/boot/bootman/efi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/bootman/pcat/Makefile
+++ b/boot/bootman/pcat/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/bootman/sources
+++ b/boot/bootman/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/fatboot/Makefile
+++ b/boot/fatboot/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/lib/Makefile
+++ b/boot/lib/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/lib/efi/Makefile
+++ b/boot/lib/efi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/lib/pcat/Makefile
+++ b/boot/lib/pcat/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/lib/sources
+++ b/boot/lib/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/loader/Makefile
+++ b/boot/loader/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/loader/efi/Makefile
+++ b/boot/loader/efi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/loader/pcat/Makefile
+++ b/boot/loader/pcat/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/loader/sources
+++ b/boot/loader/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/boot/mbr/Makefile
+++ b/boot/mbr/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/acpi/Makefile
+++ b/drivers/acpi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/ata/Makefile
+++ b/drivers/ata/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/devrem/Makefile
+++ b/drivers/devrem/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/dma/Makefile
+++ b/drivers/dma/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/dma/bcm2709/Makefile
+++ b/drivers/dma/bcm2709/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/dma/core/Makefile
+++ b/drivers/dma/core/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/dma/edma3/Makefile
+++ b/drivers/dma/edma3/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/fat/Makefile
+++ b/drivers/fat/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/gpio/Makefile
+++ b/drivers/gpio/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/gpio/broadcom/Makefile
+++ b/drivers/gpio/broadcom/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/gpio/broadcom/bc27/Makefile
+++ b/drivers/gpio/broadcom/bc27/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/gpio/core/Makefile
+++ b/drivers/gpio/core/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/gpio/rockchip/Makefile
+++ b/drivers/gpio/rockchip/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/gpio/rockchip/rk32/Makefile
+++ b/drivers/gpio/rockchip/rk32/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/gpio/ti/Makefile
+++ b/drivers/gpio/ti/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/gpio/ti/omap4/Makefile
+++ b/drivers/gpio/ti/omap4/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/i8042/Makefile
+++ b/drivers/i8042/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/i8042/pl050/Makefile
+++ b/drivers/i8042/pl050/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/net/Makefile
+++ b/drivers/net/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/net/ethernet/Makefile
+++ b/drivers/net/ethernet/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/net/ethernet/am3eth/Makefile
+++ b/drivers/net/ethernet/am3eth/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/net/ethernet/atl1c/Makefile
+++ b/drivers/net/ethernet/atl1c/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/net/ethernet/dwceth/Makefile
+++ b/drivers/net/ethernet/dwceth/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/net/ethernet/e100/Makefile
+++ b/drivers/net/ethernet/e100/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/net/ethernet/rtl81xx/Makefile
+++ b/drivers/net/ethernet/rtl81xx/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/net/ethernet/smsc91c1/Makefile
+++ b/drivers/net/ethernet/smsc91c1/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/net/ethernet/smsc95xx/Makefile
+++ b/drivers/net/ethernet/smsc95xx/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/net/net80211/Makefile
+++ b/drivers/net/net80211/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/net/netcore/Makefile
+++ b/drivers/net/netcore/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/net/wireless/Makefile
+++ b/drivers/net/wireless/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/net/wireless/rtlw81xx/Makefile
+++ b/drivers/net/wireless/rtlw81xx/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/null/Makefile
+++ b/drivers/null/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/part/Makefile
+++ b/drivers/part/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/pci/Makefile
+++ b/drivers/pci/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/plat/Makefile
+++ b/drivers/plat/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/plat/goec/Makefile
+++ b/drivers/plat/goec/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/plat/quark/Makefile
+++ b/drivers/plat/quark/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/plat/quark/qrkhostb/Makefile
+++ b/drivers/plat/quark/qrkhostb/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/plat/rockchip/Makefile
+++ b/drivers/plat/rockchip/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/plat/rockchip/rk808/Makefile
+++ b/drivers/plat/rockchip/rk808/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/plat/ti/Makefile
+++ b/drivers/plat/ti/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/plat/ti/am3soc/Makefile
+++ b/drivers/plat/ti/am3soc/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/plat/ti/tps65217/Makefile
+++ b/drivers/plat/ti/tps65217/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/ramdisk/Makefile
+++ b/drivers/ramdisk/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/spb/Makefile
+++ b/drivers/spb/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/spb/core/Makefile
+++ b/drivers/spb/core/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/spb/i2c/Makefile
+++ b/drivers/spb/i2c/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/spb/i2c/am3i2c/Makefile
+++ b/drivers/spb/i2c/am3i2c/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/spb/i2c/rk3i2c/Makefile
+++ b/drivers/spb/i2c/rk3i2c/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/spb/spi/Makefile
+++ b/drivers/spb/spi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/spb/spi/rk32spi/Makefile
+++ b/drivers/spb/spi/rk32spi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/special/Makefile
+++ b/drivers/special/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/term/Makefile
+++ b/drivers/term/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/term/ser16550/Makefile
+++ b/drivers/term/ser16550/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/usb/Makefile
+++ b/drivers/usb/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/usb/am3usb/Makefile
+++ b/drivers/usb/am3usb/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/usb/dwhci/Makefile
+++ b/drivers/usb/dwhci/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/usb/ehci/Makefile
+++ b/drivers/usb/ehci/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/usb/onering/Makefile
+++ b/drivers/usb/onering/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/usb/onering/usbrelay/Makefile
+++ b/drivers/usb/onering/usbrelay/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/drivers/usb/uhci/Makefile
+++ b/drivers/usb/uhci/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/usb/usbcomp/Makefile
+++ b/drivers/usb/usbcomp/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/usb/usbcore/Makefile
+++ b/drivers/usb/usbcore/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/usb/usbhub/Makefile
+++ b/drivers/usb/usbhub/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/usb/usbkbd/Makefile
+++ b/drivers/usb/usbkbd/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/usb/usbmass/Makefile
+++ b/drivers/usb/usbmass/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/usrinput/Makefile
+++ b/drivers/usrinput/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/drivers/videocon/Makefile
+++ b/drivers/videocon/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/include/minoca/kernel/arm.inc
+++ b/include/minoca/kernel/arm.inc
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2012 Minoca Corp. All Rights Reserved
+Copyright (c) 2012 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/include/minoca/kernel/x64.inc
+++ b/include/minoca/kernel/x64.inc
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2015 Minoca Corp. All Rights Reserved
+Copyright (c) 2015 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/include/minoca/kernel/x86.inc
+++ b/include/minoca/kernel/x86.inc
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2012 Minoca Corp. All Rights Reserved
+Copyright (c) 2012 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/acpi/Makefile
+++ b/kernel/acpi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/armv6/Makefile
+++ b/kernel/armv6/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/armv6/boot/Makefile
+++ b/kernel/armv6/boot/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/armv7/Makefile
+++ b/kernel/armv7/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/armv7/boot/Makefile
+++ b/kernel/armv7/boot/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/config/init.sh
+++ b/kernel/config/init.sh
@@ -1,5 +1,10 @@
 ##
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/kernel/hl/Makefile
+++ b/kernel/hl/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/hl/boot/Makefile
+++ b/kernel/hl/boot/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/io/Makefile
+++ b/kernel/io/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/kd/Makefile
+++ b/kernel/kd/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/kd/boot/Makefile
+++ b/kernel/kd/boot/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/kd/kdusb/Makefile
+++ b/kernel/kd/kdusb/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/kd/kdusb/kdnousb/Makefile
+++ b/kernel/kd/kdusb/kdnousb/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/ke/Makefile
+++ b/kernel/ke/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/mm/Makefile
+++ b/kernel/mm/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/mm/boot/Makefile
+++ b/kernel/mm/boot/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/mm/testmm/Makefile
+++ b/kernel/mm/testmm/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/kernel/ob/Makefile
+++ b/kernel/ob/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/ps/Makefile
+++ b/kernel/ps/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/sp/Makefile
+++ b/kernel/sp/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/kernel/x86/Makefile
+++ b/kernel/x86/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/basevid/Makefile
+++ b/lib/basevid/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/lib/bconflib/Makefile
+++ b/lib/bconflib/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/lib/bconflib/build/Makefile
+++ b/lib/bconflib/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/lib/bconflib/sources
+++ b/lib/bconflib/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/lib/crypto/Makefile
+++ b/lib/crypto/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/crypto/build/Makefile
+++ b/lib/crypto/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/crypto/sources
+++ b/lib/crypto/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/lib/crypto/ssl/Makefile
+++ b/lib/crypto/ssl/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/crypto/ssl/build/Makefile
+++ b/lib/crypto/ssl/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/crypto/ssl/sources
+++ b/lib/crypto/ssl/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/lib/crypto/testcryp/Makefile
+++ b/lib/crypto/testcryp/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/lib/fatlib/Makefile
+++ b/lib/fatlib/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/lib/fatlib/build/Makefile
+++ b/lib/fatlib/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/lib/fatlib/fattest/Makefile
+++ b/lib/fatlib/fattest/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/lib/fatlib/sources
+++ b/lib/fatlib/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/lib/im/Makefile
+++ b/lib/im/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/im/build/Makefile
+++ b/lib/im/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/im/sources
+++ b/lib/im/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/lib/partlib/Makefile
+++ b/lib/partlib/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/lib/partlib/build/Makefile
+++ b/lib/partlib/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/lib/partlib/sources
+++ b/lib/partlib/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/lib/rtl/Makefile
+++ b/lib/rtl/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/rtl/base/Makefile
+++ b/lib/rtl/base/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/rtl/base/boot/Makefile
+++ b/lib/rtl/base/boot/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/rtl/base/build/Makefile
+++ b/lib/rtl/base/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/rtl/base/intrins/Makefile
+++ b/lib/rtl/base/intrins/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/rtl/base/sources
+++ b/lib/rtl/base/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2013 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2013 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/lib/rtl/base/wide/Makefile
+++ b/lib/rtl/base/wide/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/rtl/kmode/Makefile
+++ b/lib/rtl/kmode/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/rtl/rtlc/Makefile
+++ b/lib/rtl/rtlc/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/rtl/rtlc/build/Makefile
+++ b/lib/rtl/rtlc/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/rtl/testrtl/Makefile
+++ b/lib/rtl/testrtl/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/lib/termlib/Makefile
+++ b/lib/termlib/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/termlib/build/Makefile
+++ b/lib/termlib/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/lib/termlib/sources
+++ b/lib/termlib/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/lib/yy/Makefile
+++ b/lib/yy/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/lib/yy/build/Makefile
+++ b/lib/yy/build/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/lib/yy/gen/Makefile
+++ b/lib/yy/gen/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/lib/yy/sources
+++ b/lib/yy/sources
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/lib/yy/yytest/Makefile
+++ b/lib/yy/yytest/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/minoca.mk
+++ b/minoca.mk
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/tasks/build/add_files.sh
+++ b/tasks/build/add_files.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/build/autoclient.sh
+++ b/tasks/build/autoclient.sh
@@ -1,5 +1,10 @@
 #! /bin/sh
-## Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2015 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/build/dev_setup.sh
+++ b/tasks/build/dev_setup.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2015 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/build/download_build.sh
+++ b/tasks/build/download_build.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/build/download_sources.sh
+++ b/tasks/build/download_sources.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##
@@ -22,7 +27,7 @@ set -e
 
 if test -z "$SRCROOT"; then
     SRCROOT=`pwd`/src
-fi    
+fi
 
 export TMPDIR=$PWD
 export TEMP=$TMPDIR

--- a/tasks/build/install_build.sh
+++ b/tasks/build/install_build.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/build/make.sh
+++ b/tasks/build/make.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/build/package_binaries.sh
+++ b/tasks/build/package_binaries.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/build/prep_env.sh
+++ b/tasks/build/prep_env.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/build/print_version.sh
+++ b/tasks/build/print_version.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2016 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2016 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/build/setup_distrib.sh
+++ b/tasks/build/setup_distrib.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2015 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/build/upload_binaries.sh
+++ b/tasks/build/upload_binaries.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/demo/gizmo_demo.py
+++ b/tasks/demo/gizmo_demo.py
@@ -1,5 +1,10 @@
 ##
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##
@@ -133,11 +138,11 @@ index = """
 profile_page = """
 <h1>Profiling Puzzler</h1>
 <p>You've just built a new board that changes a traffic light via USB, but you
-suspect your driver is taking longer than it should when sending I/O. So you 
+suspect your driver is taking longer than it should when sending I/O. So you
 design a test to change the light rapidly, and enable Minoca's stack sampling
 profiler.</p>
 <p>Take a look at the profiling data collected on the touchscreen PC in the
-lower left pane of the debugger. Can you find out where all the CPU time is 
+lower left pane of the debugger. Can you find out where all the CPU time is
 going in your "onering" driver?
 </p>
 <p>Hint: Follow the hit counts starting at AySysenterHandlerAsm until you find
@@ -154,7 +159,7 @@ sys 8.12
 </pre>
 
 <p>
-*Comparison run on Minoca OS r867. Results are averaged (mean) across 10 runs, 
+*Comparison run on Minoca OS r867. Results are averaged (mean) across 10 runs,
 standard deviations 1.18, 0.0135, and 0.046.
 </p>
 """
@@ -182,33 +187,33 @@ class MinocaHTTPRequestHandler(BaseHTTPRequestHandler):
         send_end = True
         if self.path == '/':
             self.wfile.write(index)
-          
-        elif self.path == '/activity/':        
+
+        elif self.path == '/activity/':
             self.run_activity()
-            
+
         elif self.path == '/build_zlib/':
             self.run_compile()
-            
+
         elif self.path == '/compress_file/':
             self.run_compress()
-            
+
         elif self.path == '/calculate_primes/':
             self.run_calc_primes()
-            
+
         elif self.path == '/profile_test/':
             self.run_profile_test()
-            
+
         elif self.path == '/exit/':
             self.socket.close()
-            
+
         else:
             self.send_error(404, 'File not found!!')
             send_end = False
-            
+
         if send_end:
             self.wfile.write(html_end);
-            
-        return     
+
+        return
 
     def run_activity(self):
         nth, start, prime, tdelta = calc_primes()
@@ -216,7 +221,7 @@ class MinocaHTTPRequestHandler(BaseHTTPRequestHandler):
         self.wfile.write("<br /><br /><h2>Last Prime Calculation:</h2>")
         self.display_calc_primes(nth, start, prime, tdelta)
         return
-                
+
     def run_compile(self):
         self.wfile.write("<h1>Compiling zlib</h1>")
         print("Compiling zlib...")
@@ -225,7 +230,7 @@ class MinocaHTTPRequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(compile_compare)
         print("Done")
         return
-        
+
     def run_compress(self):
         self.wfile.write("<h1>Compressing some files</h1>")
         print("Compressing some files...")
@@ -240,7 +245,7 @@ class MinocaHTTPRequestHandler(BaseHTTPRequestHandler):
         nth, start, prime, tdelta = calc_primes()
         self.display_calc_primes(nth, start, prime, tdelta)
         return
-       
+
     def run_profile_test(self):
         print("Enabling kernel stack sampling")
         print("Changing light rapidly to aggregate samples.")
@@ -253,40 +258,40 @@ class MinocaHTTPRequestHandler(BaseHTTPRequestHandler):
             i += 1
             time.sleep(0.1)
             t1 = datetime.datetime.now()
-            
+
         print("Disabling kernel stack sampling")
         minoca_set_profiling(False)
         self.wfile.write(profile_page)
         return
-        
+
     def run_command(self, args):
         process = subprocess.Popen(args=args,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE,
                                    shell=False,
                                    env=os.environ)
-                                   
+
         out, err = process.communicate()
         result = "<pre>"
         result += "Process %d exited with status %d\n" % \
                  (process.pid, process.returncode)
-                 
+
         result += out
         if err:
             result += "stderr: " + err
-            
+
         result += "</pre>"
         self.wfile.write(result)
         return
-        
+
     def display_calc_primes(self, nth, start, prime, tdelta):
         result = "<p>The %dth prime number starting at %d is %d.</p>" % \
                  (nth, start, prime)
-                     
+
         result += "<p>Calculated in %f seconds.</p>" % tdelta
-        self.wfile.write(result)        
+        self.wfile.write(result)
         return
-        
+
 def change_light(value):
     value = int(value) % 8
     os.system("./usbrelay %d" % value)
@@ -299,7 +304,7 @@ def calc_primes():
     t1 = datetime.datetime.now()
     tdelta = (t1 - t0).total_seconds()
     return (nth, start, prime, tdelta)
-    
+
 def is_prime(num):
     for j in range(2,int(math.sqrt(num)+1)):
         if (num % j) == 0:
@@ -319,23 +324,23 @@ def calc_nth_prime(start, nth):
     while i < nth:
         if is_prime(num):
             i += 1
-            
+
             ##
             ## Periodically update the light.
             ##
-            
+
             if i >= update:
                 change_light(num / 4)
                 print "%d: %d" % (i, num)
                 update += random.randint(300, 2500)
-                
+
             if i == nth:
                 return num
-                
+
         num += 1
-        
+
     return 0
-    
+
 ##
 ## Define some Minoca specific C constants.
 ##
@@ -359,14 +364,14 @@ class SP_GET_SET_STATE_INFORMATION(ctypes.Structure):
         ("operation", ctypes.c_ulong),
         ("profilertypeflags", ctypes.c_ulong)
     ]
-    
+
 def minoca_set_profiling(enable):
     information = SP_GET_SET_STATE_INFORMATION()
     information.operation = SpGetSetStateOperationDisable
     information.profilertypeflags = PROFILER_TYPE_FLAG_STACK_SAMPLING;
     if enable:
         information.operation = SpGetSetStateOperationEnable
-        
+
     information_pointer = ctypes.cast(ctypes.addressof(information),
                                       ctypes.c_char_p)
 
@@ -379,9 +384,9 @@ def minoca_set_profiling(enable):
 
     if result != STATUS_SUCCESS:
         print("Failed to get profiling: %d" % result)
-        
+
     return
-        
+
 def minoca_get_set_system_information(c_type,
                                       c_subtype,
                                       c_buffer,
@@ -416,8 +421,8 @@ if __name__ == '__main__':
     ##
     ## Symlink /bin/time in case I forget.
     ##
-    
+
     if (not os.path.exists('/bin/time')) and (os.path.exists('/bin/swiss')):
         os.symlink('swiss', '/bin/time')
-        
+
     run()

--- a/tasks/distrib/gen_bin.sh
+++ b/tasks/distrib/gen_bin.sh
@@ -1,5 +1,10 @@
 ##
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/distrib/gen_inst.sh
+++ b/tasks/distrib/gen_inst.sh
@@ -1,5 +1,10 @@
 ##
-## Copyright (c) 2016 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2016 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/distrib/gen_plats.sh
+++ b/tasks/distrib/gen_plats.sh
@@ -1,5 +1,10 @@
 ##
-## Copyright (c) 2016 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2016 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/distrib/gen_sdk.sh
+++ b/tasks/distrib/gen_sdk.sh
@@ -1,5 +1,10 @@
 ##
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##
@@ -129,7 +134,12 @@ cp -pv "$SRCROOT/os/minoca.mk" "$WORKING/os"
 cat > "$WORKING/os/Makefile" <<_EOS
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #
@@ -176,7 +186,12 @@ _EOS
 cat > "$WORKING/os/drivers/Makefile" <<_EOS
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #
@@ -208,7 +223,12 @@ _EOS
 cat > "$WORKING/os/drivers/usb/Makefile" <<_EOS
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #
@@ -237,7 +257,12 @@ _EOS
 cat > "$WORKING/os/drivers/net/Makefile" <<_EOS
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #
@@ -266,7 +291,12 @@ _EOS
 cat > "$WORKING/os/drivers/net/ethernet/Makefile" <<_EOS
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #
@@ -295,7 +325,12 @@ _EOS
 cat > "$WORKING/os/apps/Makefile" <<_EOS
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/tasks/distrib/gen_syms.sh
+++ b/tasks/distrib/gen_syms.sh
@@ -1,5 +1,10 @@
 ##
-## Copyright (c) 2016 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2016 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/distrib/gen_tp.sh
+++ b/tasks/distrib/gen_tp.sh
@@ -1,5 +1,10 @@
 ##
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/osbuilder/build_image.py
+++ b/tasks/osbuilder/build_image.py
@@ -1,5 +1,10 @@
 #! /usr/bin/python
-## Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2015 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/osbuilder/build_image.sh
+++ b/tasks/osbuilder/build_image.sh
@@ -1,5 +1,10 @@
 #! /bin/sh
-## Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2015 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/osbuilder/update_packages.sh
+++ b/tasks/osbuilder/update_packages.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2015 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/test/cpu_info.py
+++ b/tasks/test/cpu_info.py
@@ -1,5 +1,10 @@
 ##
-## Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2015 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/test/perf_test.sh
+++ b/tasks/test/perf_test.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2015 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/winbuild/git_up.sh
+++ b/tasks/winbuild/git_up.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/winbuild/make.sh
+++ b/tasks/winbuild/make.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/winbuild/package_binaries.sh
+++ b/tasks/winbuild/package_binaries.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/winbuild/package_distrib.sh
+++ b/tasks/winbuild/package_distrib.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/winbuild/package_source.sh
+++ b/tasks/winbuild/package_source.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/winbuild/upload_binaries.sh
+++ b/tasks/winbuild/upload_binaries.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/tasks/winbuild/upload_source.sh
+++ b/tasks/winbuild/upload_source.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-## Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+## Copyright (c) 2014 Minoca Corp.
+##
+##    This file is licensed under the terms of the GNU General Public License
+##    version 3. Alternative licensing terms are available. Contact
+##    info@minocacorp.com for details. See the LICENSE file at the root of this
+##    project for complete licensing information..
 ##
 ## Script Name:
 ##

--- a/uefi/Makefile
+++ b/uefi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/archlib/Makefile
+++ b/uefi/archlib/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/core/Makefile
+++ b/uefi/core/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/core/emptyrd/Makefile
+++ b/uefi/core/emptyrd/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/core/rtlib/Makefile
+++ b/uefi/core/rtlib/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/core/runtime/Makefile
+++ b/uefi/core/runtime/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/dev/Makefile
+++ b/uefi/dev/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/dev/bcm2709/Makefile
+++ b/uefi/dev/bcm2709/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/dev/common
+++ b/uefi/dev/common
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/dev/gic/Makefile
+++ b/uefi/dev/gic/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/dev/gt/Makefile
+++ b/uefi/dev/gt/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2016 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2016 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/dev/ns16550/Makefile
+++ b/uefi/dev/ns16550/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/dev/omap4/Makefile
+++ b/uefi/dev/omap4/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/dev/omapuart/Makefile
+++ b/uefi/dev/omapuart/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/dev/pl031/Makefile
+++ b/uefi/dev/pl031/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/dev/pl11/Makefile
+++ b/uefi/dev/pl11/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/dev/pl110/Makefile
+++ b/uefi/dev/pl110/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/dev/sd/Makefile
+++ b/uefi/dev/sd/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/dev/sd/core/Makefile
+++ b/uefi/dev/sd/core/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/dev/sd/dwc/Makefile
+++ b/uefi/dev/sd/dwc/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/plat/Makefile
+++ b/uefi/plat/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/beagbone/Makefile
+++ b/uefi/plat/beagbone/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/beagbone/acpi/Makefile
+++ b/uefi/plat/beagbone/acpi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/beagbone/acpi/am33.asl
+++ b/uefi/plat/beagbone/acpi/am33.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2015 Minoca Corp. All Rights Reserved
+Copyright (c) 2015 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/beagbone/acpi/dbg2.asl
+++ b/uefi/plat/beagbone/acpi/dbg2.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2015 Minoca Corp. All Rights Reserved
+Copyright (c) 2015 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/beagbone/acpi/dsdt.asl
+++ b/uefi/plat/beagbone/acpi/dsdt.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+Copyright (c) 2015 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information..
 
 Module Name:
 

--- a/uefi/plat/beagbone/acpi/facp.asl
+++ b/uefi/plat/beagbone/acpi/facp.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/beagbone/acpi/facs.asl
+++ b/uefi/plat/beagbone/acpi/facs.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/beagbone/init/Makefile
+++ b/uefi/plat/beagbone/init/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/beagbone/init/bbonefwb/Makefile
+++ b/uefi/plat/beagbone/init/bbonefwb/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/plat/beagbone/runtime/Makefile
+++ b/uefi/plat/beagbone/runtime/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/bios/Makefile
+++ b/uefi/plat/bios/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/bios/runtime/Makefile
+++ b/uefi/plat/bios/runtime/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/common
+++ b/uefi/plat/common
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/plat/integcp/Makefile
+++ b/uefi/plat/integcp/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/integcp/acpi/Makefile
+++ b/uefi/plat/integcp/acpi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/integcp/acpi/dbg2.asl
+++ b/uefi/plat/integcp/acpi/dbg2.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/integcp/acpi/facp.asl
+++ b/uefi/plat/integcp/acpi/facp.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/integcp/acpi/facs.asl
+++ b/uefi/plat/integcp/acpi/facs.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/integcp/acpi/incp.asl
+++ b/uefi/plat/integcp/acpi/incp.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/integcp/runtime/Makefile
+++ b/uefi/plat/integcp/runtime/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/panda/Makefile
+++ b/uefi/plat/panda/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/panda/acpi/Makefile
+++ b/uefi/plat/panda/acpi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/panda/acpi/apic.asl
+++ b/uefi/plat/panda/acpi/apic.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/panda/acpi/dbg2.asl
+++ b/uefi/plat/panda/acpi/dbg2.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/panda/acpi/facp.asl
+++ b/uefi/plat/panda/acpi/facp.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/panda/acpi/facs.asl
+++ b/uefi/plat/panda/acpi/facs.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/panda/acpi/omp4.asl
+++ b/uefi/plat/panda/acpi/omp4.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/panda/init/Makefile
+++ b/uefi/plat/panda/init/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/panda/init/fwbuild/Makefile
+++ b/uefi/plat/panda/init/fwbuild/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/plat/panda/runtime/Makefile
+++ b/uefi/plat/panda/runtime/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/rpi/Makefile
+++ b/uefi/plat/rpi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2012 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2012 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/rpi/acpi/Makefile
+++ b/uefi/plat/rpi/acpi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/rpi/acpi/bcm2.asl
+++ b/uefi/plat/rpi/acpi/bcm2.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 
@@ -99,7 +104,7 @@ Environment:
 //
 
                                    UINT64 : 000000002000B880
-                                   
+
 //
 // Local CPU physical address.
 //

--- a/uefi/plat/rpi/acpi/dbg2.asl
+++ b/uefi/plat/rpi/acpi/dbg2.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/rpi/acpi/dsdt.asl
+++ b/uefi/plat/rpi/acpi/dsdt.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved.
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information..
 
 Module Name:
 
@@ -41,7 +46,7 @@ DefinitionBlock (
             Name(_UID, 0)
 
             /*
-             * Define the operation region to access the DWC configuration 
+             * Define the operation region to access the DWC configuration
              * space.
              */
 
@@ -55,7 +60,7 @@ DefinitionBlock (
                 SKP2, 8,
                 USRP, 1,
                 UHNP, 1,
-                Offset(0x24),                 
+                Offset(0x24),
                 RXFS, 16,
                 Offset(0x28),
                 NPFO, 16,
@@ -67,15 +72,15 @@ DefinitionBlock (
 
             /*
              * Set the AHB configuration register to have a single burst length
-             * and to wait on all writes. Also set the receive FIFO to 774 
+             * and to wait on all writes. Also set the receive FIFO to 774
              * bytes, the non-periodic transmit FIFO to 256 bytes, and the
              * periodic transmit FIFO to 512 bytes. The Raspberry Pi's DWC USB
-             * controller allows dynamic FIFO sizes and the maximum FIFO depth 
+             * controller allows dynamic FIFO sizes and the maximum FIFO depth
              * is greater than the total FIFO sizes programmed here. Lastly,
              * the host is both SRP and HNP capable.
-             */       
-            
-            Method(_INI, 0) {                        
+             */
+
+            Method(_INI, 0) {
                 Store(0x306, RXFS)
                 Store(0x306, NPFO)
                 Store(0x100, NPFS)

--- a/uefi/plat/rpi/acpi/facp.asl
+++ b/uefi/plat/rpi/acpi/facp.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/rpi/acpi/facs.asl
+++ b/uefi/plat/rpi/acpi/facs.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/rpi/blobs/Makefile
+++ b/uefi/plat/rpi/blobs/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/plat/rpi/runtime/Makefile
+++ b/uefi/plat/rpi/runtime/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/rpi2/Makefile
+++ b/uefi/plat/rpi2/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/rpi2/acpi/Makefile
+++ b/uefi/plat/rpi2/acpi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/rpi2/acpi/bcm2.asl
+++ b/uefi/plat/rpi2/acpi/bcm2.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2015 Minoca Corp. All Rights Reserved
+Copyright (c) 2015 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 
@@ -109,7 +114,7 @@ Environment:
 //
 // Processor 0 information. See BCM2709_CPU_ENTRY.
 //
-                                   
+
                                     UINT8 : 00
                                     UINT8 : 18
                                    UINT16 : 0000
@@ -121,7 +126,7 @@ Environment:
 //
 // Processor 1 information. See BCM2709_CPU_ENTRY.
 //
-                                   
+
                                     UINT8 : 00
                                     UINT8 : 18
                                    UINT16 : 0000
@@ -129,11 +134,11 @@ Environment:
                                    UINT32 : 00000001
                                    UINT32 : 00000000
                                    UINT64 : 0000000001FFB000
-                                   
+
 //
 // Processor 2 information. See BCM2709_CPU_ENTRY.
 //
-                                   
+
                                     UINT8 : 00
                                     UINT8 : 18
                                    UINT16 : 0000
@@ -145,7 +150,7 @@ Environment:
 //
 // Processor 3 information. See BCM2709_CPU_ENTRY.
 //
-                                   
+
                                     UINT8 : 00
                                     UINT8 : 18
                                    UINT16 : 0000

--- a/uefi/plat/rpi2/acpi/dbg2.asl
+++ b/uefi/plat/rpi2/acpi/dbg2.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2015 Minoca Corp. All Rights Reserved
+Copyright (c) 2015 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/rpi2/acpi/dsdt.asl
+++ b/uefi/plat/rpi2/acpi/dsdt.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+Copyright (c) 2015 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information..
 
 Module Name:
 
@@ -41,7 +46,7 @@ DefinitionBlock (
             Name(_UID, 0)
 
             /*
-             * Define the operation region to access the DWC configuration 
+             * Define the operation region to access the DWC configuration
              * space.
              */
 
@@ -67,15 +72,15 @@ DefinitionBlock (
 
             /*
              * Set the AHB configuration register to have a single burst length
-             * and to wait on all writes. Also set the receive FIFO to 774 
+             * and to wait on all writes. Also set the receive FIFO to 774
              * bytes, the non-periodic transmit FIFO to 256 bytes, and the
              * periodic transmit FIFO to 512 bytes. The Raspberry Pi's DWC USB
-             * controller allows dynamic FIFO sizes and the maximum FIFO depth 
+             * controller allows dynamic FIFO sizes and the maximum FIFO depth
              * is greater than the total FIFO sizes programmed here. Lastly,
              * the host is both SRP and HNP capable.
-             */       
-            
-            Method(_INI, 0) {                        
+             */
+
+            Method(_INI, 0) {
                 Store(0x306, RXFS)
                 Store(0x306, NPFO)
                 Store(0x100, NPFS)

--- a/uefi/plat/rpi2/acpi/facp.asl
+++ b/uefi/plat/rpi2/acpi/facp.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/rpi2/acpi/facs.asl
+++ b/uefi/plat/rpi2/acpi/facs.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/rpi2/acpi/gtdt.asl
+++ b/uefi/plat/rpi2/acpi/gtdt.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2016 Minoca Corp. All Rights Reserved
+Copyright (c) 2016 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/rpi2/blobs/Makefile
+++ b/uefi/plat/rpi2/blobs/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/plat/rpi2/blobs/config.txt
+++ b/uefi/plat/rpi2/blobs/config.txt
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   File Name:
 #

--- a/uefi/plat/rpi2/runtime/Makefile
+++ b/uefi/plat/rpi2/runtime/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/veyron/Makefile
+++ b/uefi/plat/veyron/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/veyron/acpi/Makefile
+++ b/uefi/plat/veyron/acpi/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/plat/veyron/acpi/apic.asl
+++ b/uefi/plat/veyron/acpi/apic.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2015 Minoca Corp. All Rights Reserved
+Copyright (c) 2015 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/veyron/acpi/dbg2.asl
+++ b/uefi/plat/veyron/acpi/dbg2.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2014 Minoca Corp. All Rights Reserved
+Copyright (c) 2014 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/veyron/acpi/dsdt.asl
+++ b/uefi/plat/veyron/acpi/dsdt.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2015 Minoca Corp. All Rights Reserved.
+Copyright (c) 2015 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information..
 
 Module Name:
 

--- a/uefi/plat/veyron/acpi/facp.asl
+++ b/uefi/plat/veyron/acpi/facp.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2015 Minoca Corp. All Rights Reserved
+Copyright (c) 2015 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/veyron/acpi/facs.asl
+++ b/uefi/plat/veyron/acpi/facs.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2015 Minoca Corp. All Rights Reserved
+Copyright (c) 2015 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/veyron/acpi/gtdt.asl
+++ b/uefi/plat/veyron/acpi/gtdt.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2016 Minoca Corp. All Rights Reserved
+Copyright (c) 2016 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/veyron/acpi/rk32.asl
+++ b/uefi/plat/veyron/acpi/rk32.asl
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2015 Minoca Corp. All Rights Reserved
+Copyright (c) 2015 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/veyron/armv7/smp.inc
+++ b/uefi/plat/veyron/armv7/smp.inc
@@ -1,6 +1,11 @@
 /*++
 
-Copyright (c) 2016 Minoca Corp. All Rights Reserved
+Copyright (c) 2016 Minoca Corp.
+
+    This file is licensed under the terms of the GNU General Public License
+    version 3. Alternative licensing terms are available. Contact
+    info@minocacorp.com for details. See the LICENSE file at the root of this
+    project for complete licensing information.
 
 Module Name:
 

--- a/uefi/plat/veyron/fwbuild/Makefile
+++ b/uefi/plat/veyron/fwbuild/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/plat/veyron/runtime/Makefile
+++ b/uefi/plat/veyron/runtime/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/tools/Makefile
+++ b/uefi/tools/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Module Name:
 #

--- a/uefi/tools/elfconv/Makefile
+++ b/uefi/tools/elfconv/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/tools/genffs/Makefile
+++ b/uefi/tools/genffs/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/tools/genfv/Makefile
+++ b/uefi/tools/genfv/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2014 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2014 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #

--- a/uefi/tools/mkuboot/Makefile
+++ b/uefi/tools/mkuboot/Makefile
@@ -1,6 +1,11 @@
 ################################################################################
 #
-#   Copyright (c) 2015 Minoca Corp. All Rights Reserved
+#   Copyright (c) 2015 Minoca Corp.
+#
+#    This file is licensed under the terms of the GNU General Public License
+#    version 3. Alternative licensing terms are available. Contact
+#    info@minocacorp.com for details. See the LICENSE file at the root of this
+#    project for complete licensing information.
 #
 #   Binary Name:
 #


### PR DESCRIPTION
> The contributions file mentions that I should post patches to the mailing list, but it looks like patches are being accepted (indirectly) via PRs as well.

Since I'm using Mac OS X (10.11), I hard to learn the hard way that BSD and GNU sed treated newlines differently. I read about the difference between GNU and BSD sed thanks to a very helpful [SO comment][1] that explained the differences and solution.

The solution was to simply use GNU `sed` instead (pun intended) by installing it via Homebrew:
```bash
brew install gnu-sed
```

Using that along with `find`, allowed me to search through every file and call `gsed`:
```bash
find ./ -type f -exec sed -i -e 's/foo/bar/g' {} \;
```

Eventually I ended up with this regex:

```bash
find ./ -type f -exec gsed -i "s/Copyright (c) 2012 Minoca Corp. All Rights Reserved/Copyright (c) 2012 Minoca Corp.\n#\n#    This file is licensed under the terms of the GNU General Public License\n#    version 3. Alternative licensing terms are available. Contact\n#    info@minocacorp.com for details. See the LICENSE file at the root of this\n#    project for complete licensing information.\n#/" {} \;
```

Notes: I've replaced the copyright for each year with the GPL eqivalent with the same. i.e Copyright for 2012 gets a GPL since 2012, etc. 

[1]: http://stackoverflow.com/a/24276470/936067