### PR TITLE
Fix "module memory" documentation grammar error

### DIFF
--- a/kernel/mm/armv7/usermem.S
+++ b/kernel/mm/armv7/usermem.S
@@ -13,9 +13,9 @@ Module Name:
 
 Abstract:
 
-    This module memory manipulation routines to and from user mode buffers.
-    The page fault handler knows about these functions specifically and may
-    manipulate the instruction pointer if it is found in one of these
+    This module contains memory manipulation routines to and from user mode
+    buffers. The page fault handler knows about these functions specifically
+    and may manipulate the instruction pointer if it is found in one of these
     functions. These routines may fail if user mode passes a bad buffer.
 
 Author:

--- a/kernel/mm/x86/usermem.S
+++ b/kernel/mm/x86/usermem.S
@@ -13,9 +13,9 @@ Module Name:
 
 Abstract:
 
-    This module memory manipulation routines to and from user mode buffers.
-    The page fault handler knows about these functions specifically and may
-    manipulate the instruction pointer if it is found in one of these
+    This module contains memory manipulation routines to and from user mode
+    buffers. The page fault handler knows about these functions specifically
+    and may manipulate the instruction pointer if it is found in one of these
     functions. These routines may fail if user mode passes a bad buffer.
 
 Author:

--- a/lib/rtl/base/armv7/rtlmem.S
+++ b/lib/rtl/base/armv7/rtlmem.S
@@ -13,7 +13,7 @@ Module Name:
 
 Abstract:
 
-    This module memory routines in assembly, for speed.
+    This module contains memory routines in assembly, for speed.
 
 Author:
 

--- a/lib/rtl/base/x64/rtlmem.S
+++ b/lib/rtl/base/x64/rtlmem.S
@@ -13,7 +13,7 @@ Module Name:
 
 Abstract:
 
-    This module memory routines in assembly, for speed.
+    This module contains memory routines in assembly, for speed.
 
 Author:
 

--- a/lib/rtl/base/x86/rtlmem.S
+++ b/lib/rtl/base/x86/rtlmem.S
@@ -13,7 +13,7 @@ Module Name:
 
 Abstract:
 
-    This module memory routines in assembly, for speed.
+    This module contains memory routines in assembly, for speed.
 
 Author:
 


### PR DESCRIPTION
I did not update the Author section of the comment headers for the changed files. Should I have done this?