### PR TITLE
Fix build of apps/debug on FreeBSD

### DIFF
--- a/apps/debug/client/uos/Makefile
+++ b/apps/debug/client/uos/Makefile
@@ -41,9 +41,17 @@ TARGETLIBS = $(OBJROOT)/os/lib/im/build/im.a              \
              $(OBJROOT)/os/lib/rtl/base/build/basertl.a   \
              $(OBJROOT)/os/lib/rtl/rtlc/build/rtlc.a      \
 
+OS ?= $(shell uname -s)
+
 ifneq ($(OS),$(filter Windows_NT Minoca FreeBSD,$(OS)))
 
-DYNLIBS = -ldl -pthread
+DYNLIBS = -ldl
+
+endif
+
+ifneq ($(OS),$(filter Windows_NT Minoca,$(OS)))
+
+DYNLIBS = -pthread
 
 endif
 

--- a/apps/debug/client/uos/commos.c
+++ b/apps/debug/client/uos/commos.c
@@ -38,7 +38,11 @@ Environment:
 #include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
+#ifdef __FreeBSD__
+#define __freadahead(stream) 0
+#else
 #include <stdio_ext.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
@@ -281,8 +285,9 @@ Return Value:
 --*/
 
 {
+    pthread_t Thread;
 
-    return pthread_create(NULL, NULL, ThreadRoutine, Parameter);
+    return pthread_create(&Thread, NULL, ThreadRoutine, Parameter);
 }
 
 int


### PR DESCRIPTION
* fix OS detection in Makefile (it was always empty string)
* FreeBSD does not have stdio_ext.h, and __freadahead, so make it always return 0
* clang does not allow compile code where first argument is NULL