### PR TITLE
Fix debug client build on Linux

### DIFF
--- a/apps/debug/client/uos/Makefile
+++ b/apps/debug/client/uos/Makefile
@@ -45,13 +45,13 @@ OS ?= $(shell uname -s)
 
 ifneq ($(OS),$(filter Windows_NT Minoca FreeBSD,$(OS)))
 
-DYNLIBS = -ldl
+DYNLIBS += -ldl
 
 endif
 
 ifneq ($(OS),$(filter Windows_NT Minoca,$(OS)))
 
-DYNLIBS = -pthread
+DYNLIBS += -pthread
 
 endif
 


### PR DESCRIPTION
On Linux, second DYNLIBS overrides the first one,
and compiler fails to link binary without libdl.