### PR TITLE
Remove unnecessary asserts in *.set parsers

### DIFF
--- a/kernel/io/init.c
+++ b/kernel/io/init.c
@@ -794,9 +794,6 @@ Return Value:
             //
 
             if (LineEnd - Device < 2) {
-
-                ASSERT(LineEnd != Device);
-
                 if (LineEnd + 3 >= FileEnd) {
                     break;
                 }
@@ -931,8 +928,6 @@ Return Value:
             //
 
             if (LineEnd - Device < 2) {
-
-                ASSERT(LineEnd != Device);
 
                 if (LineEnd + 3 >= FileEnd) {
                     break;


### PR DESCRIPTION
When file contains \n\n, lookup function might return
pointer to the beginning of the string, which is okay,
and should not be treated as invalid state.