### PR TITLE
Develop1

### DIFF
--- a/boot/fatboot/vbr.S
+++ b/boot/fatboot/vbr.S
@@ -408,7 +408,7 @@ Gdt:
 GdtTable:
     .long   0x0                         # The first GDT entry is called the
     .long   0x0                         # null descriptor, it is essentially
-                                        # unused by the processor.
+                                       // unused by the processor.
 
 //
 // Kernel code segment descriptor

--- a/boot/lib/pcat/x64/realmexe.S
+++ b/boot/lib/pcat/x64/realmexe.S
@@ -329,7 +329,7 @@ FwpRealModeBiosCallTemplateLongJump3:
 Fwp16BitGdtTable:
     .long   0x0                         # The first GDT entry is called the
     .long   0x0                         # null descriptor, it is essentially
-                                        # unused by the processor.
+                                       // unused by the processor.
 
 //
 // Define the code segment descriptor.

--- a/boot/lib/pcat/x86/realmexe.S
+++ b/boot/lib/pcat/x86/realmexe.S
@@ -296,7 +296,7 @@ Fwp16BitGdt:
 Fwp16BitGdtTable:
     .long   0x0                         # The first GDT entry is called the
     .long   0x0                         # null descriptor, it is essentially
-                                        # unused by the processor.
+                                       // unused by the processor.
 
 //
 // Define the code segment descriptor.

--- a/kernel/hl/x64/apstart.S
+++ b/kernel/hl/x64/apstart.S
@@ -220,7 +220,7 @@ TemporaryGdt:
 TemporaryGdtTable:
     .long   0x0                         # The first GDT entry is called the
     .long   0x0                         # null descriptor, it is essentially
-                                        # unused by the processor.
+                                       // unused by the processor.
 
 //
 // Kernel 64-bit code segment descriptor

--- a/kernel/hl/x86/apstart.S
+++ b/kernel/hl/x86/apstart.S
@@ -190,7 +190,7 @@ TemporaryGdt:
 TemporaryGdtTable:
     .long   0x0                         # The first GDT entry is called the
     .long   0x0                         # null descriptor, it is essentially
-                                        # unused by the processor.
+                                       // unused by the processor.
 
 //
 // Kernel code segment descriptor

--- a/uefi/plat/bios/x86/realmexe.S
+++ b/uefi/plat/bios/x86/realmexe.S
@@ -297,7 +297,7 @@ Efi16BitGdt:
 Efi16BitGdtTable:
     .long   0x0                         # The first GDT entry is called the
     .long   0x0                         # null descriptor, it is essentially
-                                        # unused by the processor.
+                                       // unused by the processor.
 
 //
 // Define the code segment descriptor.


### PR DESCRIPTION
To compile *.S files in MSVC , I execute the following command:
cl /E "%(FullPath)" /I include /D__WINNT__ /D__ASM__ | as -o "%(Filename).obj"
But when the compiler encounters a comment delimiter # in an empty string, the compiler generates an error.
To can also correct this error for MSVC by deleting an empty line before the comment delimiter #.
--Olexandr.