### PR TITLE
uefi: Fix EfiIoPortIn32 Get the I/O port

### DIFF
--- a/uefi/archlib/x64/ioport.S
+++ b/uefi/archlib/x64/ioport.S
@@ -140,7 +140,6 @@ Return Value:
 FUNCTION(EfiIoPortIn32)
     movl    %edi, %edx              # Get port number in the right register.
     xorl    %eax, %eax              # Clear the upper word.
-    movl    4(%esp), %edx           # Get the I/O port.
     inl     %dx, %eax               # Perform the I/O port read.
     nop                             # Rest a touch.
     retq                            # Return.


### PR DESCRIPTION
In the x64 system, the first 6 (AMD64 ABI) function parameters are passed through registers.
The bug is most likely associated with copying a function from the x86/ioport.S .